### PR TITLE
feat: rename project to aprendeSwift and update branding

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -6,7 +6,8 @@
       "Bash(git add:*)",
       "Bash(git checkout:*)",
       "Bash(git pull:*)",
-      "Bash(npm run build:*)"
+      "Bash(npm run build:*)",
+      "Bash(gh pr list:*)"
     ],
     "deny": []
   }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# 🚀 Swiftly
+# 🚀 aprendeSwift
 
-**Swiftly** es una plataforma moderna para publicar y descubrir posts y tutoriales sobre **Swift** y **SwiftUI**. Diseñada para desarrolladores iOS, esta app permite compartir conocimiento de forma rápida, elegante y estructurada.
+**aprendeSwift** es una plataforma moderna para publicar y descubrir posts y tutoriales sobre **Swift** y **SwiftUI**. Diseñada para desarrolladores iOS, esta app permite compartir conocimiento de forma rápida, elegante y estructurada.
 
 ---
 
@@ -29,7 +29,7 @@ yarn && yarn dev
 pnpm install && pnpm dev
 ```
 
-Luego abre [http://localhost:3000](http://localhost:3000) para ver Swiftly en acción 🚀  
+Luego abre [http://localhost:3000](http://localhost:3000) para ver aprendeSwift en acción 🚀  
 Puedes empezar a editar modificando el archivo `app/page.tsx`.
 
 ---
@@ -67,7 +67,7 @@ O sigue la [guía oficial de despliegue](https://nextjs.org/docs/app/building-yo
 
 ## 🤝 Contribuciones
 
-¿Quieres ayudar a mejorar Swiftly?
+¿Quieres ayudar a mejorar aprendeSwift?
 
 1. Haz un fork del repo
 2. Crea una rama (`feat/nueva-funcionalidad`)
@@ -79,7 +79,7 @@ O sigue la [guía oficial de despliegue](https://nextjs.org/docs/app/building-yo
 
 ## 🐦 Síguenos
 
-Sigue el desarrollo y comparte tus tutoriales con el hashtag `#SwiftlyApp`.
+Sigue el desarrollo y comparte tus tutoriales con el hashtag `#aprendeSwiftApp`.
 
 > Hecho con ❤️ para la comunidad Swift.
 

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "swiftly",
+  "name": "aprendeswift",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/public/robots.txt
+++ b/public/robots.txt
@@ -1,0 +1,38 @@
+# Robots.txt for aprendeSwift Blog
+# https://aprendeswift.dev
+
+User-agent: *
+Allow: /
+
+# Allow all crawlers to access main content
+Allow: /posts/
+Allow: /tutorials/
+Allow: /tags/
+Allow: /contact
+
+# Disallow admin and auth pages
+Disallow: /admin/
+Disallow: /auth/
+Disallow: /api/
+
+# Disallow draft or private content
+Disallow: /posts/draft/
+Disallow: /tutorials/draft/
+
+# Allow specific API endpoints that provide useful content
+Allow: /api/contact
+Allow: /feed.xml
+
+# Sitemap and feed locations
+Sitemap: https://aprendeswift.dev/sitemap.xml
+
+# Feed URLs for discovery
+# RSS Feed: https://aprendeswift.dev/feed.xml
+# Atom Feed: https://aprendeswift.dev/atom.xml
+# JSON Feed: https://aprendeswift.dev/feed.json
+
+# Crawl-delay for respectful crawling
+Crawl-delay: 1
+
+# Host declaration
+Host: https://aprendeswift.dev

--- a/src/app/atom.xml/route.ts
+++ b/src/app/atom.xml/route.ts
@@ -1,0 +1,121 @@
+// src/app/atom.xml/route.ts
+
+import { NextResponse } from 'next/server';
+import { collection, getDocs, query, where, orderBy, limit } from 'firebase/firestore';
+import { db } from '@/services/firebase/config';
+import { Post } from '@/types/Post';
+import { toJSDate, formatAtomDate, createExcerpt, escapeXml } from '@/utils/dateUtils';
+
+const baseUrl = 'https://aprendeswift.dev';
+const siteTitle = 'aprendeSwift Blog';
+const siteDescription = 'Artículos y tutoriales sobre desarrollo web, programación y tecnología moderna';
+const authorName = 'aprendeSwift Team';
+const authorEmail = 'hello@aprendeswift.dev';
+
+export async function GET(): Promise<NextResponse> {
+    try {
+        // Get latest published posts
+        const postsQuery = query(
+            collection(db, 'posts'),
+            where('isPublished', '==', true),
+            where('status', '==', 'published'),
+            orderBy('publishedAt', 'desc'),
+            limit(20)
+        );
+
+        const postsSnapshot = await getDocs(postsQuery);
+        const posts = postsSnapshot.docs.map(doc => ({
+            id: doc.id,
+            ...doc.data()
+        } as Post));
+
+        const lastUpdated = posts.length > 0 ? toJSDate(posts[0].publishedAt) : new Date();
+
+        // Generate Atom entries
+        const atomEntries = posts.map(post => {
+            const postUrl = post.type === 'tutorial' 
+                ? `${baseUrl}/tutorials/${post.slug}`
+                : `${baseUrl}/posts/${post.slug}`;
+            
+            const publishDate = toJSDate(post.publishedAt);
+            const updateDate = toJSDate(post.updatedAt) || publishDate;
+            const excerpt = createExcerpt(post.content || post.description || '', 300);
+            
+            // Generate categories from tags
+            const categories = (post.tags || [])
+                .map(tag => `        <category term="${escapeXml(tag)}" />`)
+                .join('\n');
+
+            return `    <entry>
+        <title>${escapeXml(post.title)}</title>
+        <link href="${postUrl}" />
+        <id>${postUrl}</id>
+        <published>${formatAtomDate(publishDate)}</published>
+        <updated>${formatAtomDate(updateDate)}</updated>
+        <author>
+            <name>${escapeXml(post.author?.name || authorName)}</name>
+            <email>${authorEmail}</email>
+        </author>
+        <summary type="text">${escapeXml(excerpt)}</summary>
+        <content type="html"><![CDATA[${post.content || excerpt}]]></content>
+${categories}
+    </entry>`;
+        }).join('\n');
+
+        const atomXml = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <title>${escapeXml(siteTitle)}</title>
+    <subtitle>${escapeXml(siteDescription)}</subtitle>
+    <link href="${baseUrl}/atom.xml" rel="self" />
+    <link href="${baseUrl}" />
+    <id>${baseUrl}/</id>
+    <updated>${formatAtomDate(lastUpdated)}</updated>
+    <author>
+        <name>${escapeXml(authorName)}</name>
+        <email>${authorEmail}</email>
+    </author>
+    <generator uri="https://nextjs.org" version="15.3.0">Next.js</generator>
+    <icon>${baseUrl}/favicon.ico</icon>
+    <logo>${baseUrl}/icons/logo.png</logo>
+
+${atomEntries}
+</feed>`;
+
+        console.log(`Generated Atom feed with ${posts.length} posts`);
+
+        // Return Atom XML with proper headers
+        return new NextResponse(atomXml, {
+            status: 200,
+            headers: {
+                'Content-Type': 'application/atom+xml; charset=utf-8',
+                'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+            },
+        });
+
+    } catch (error) {
+        console.error('Error generating Atom feed:', error);
+        
+        // Return minimal Atom feed on error
+        const errorFeed = `<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+    <title>${escapeXml(siteTitle)}</title>
+    <subtitle>${escapeXml(siteDescription)}</subtitle>
+    <link href="${baseUrl}/atom.xml" rel="self" />
+    <link href="${baseUrl}" />
+    <id>${baseUrl}/</id>
+    <updated>${formatAtomDate(new Date())}</updated>
+    <author>
+        <name>${escapeXml(authorName)}</name>
+        <email>${authorEmail}</email>
+    </author>
+</feed>`;
+
+        return new NextResponse(errorFeed, {
+            status: 200,
+            headers: {
+                'Content-Type': 'application/atom+xml; charset=utf-8',
+                'Cache-Control': 'public, max-age=300',
+            },
+        });
+    }
+}

--- a/src/app/auth/layout.tsx
+++ b/src/app/auth/layout.tsx
@@ -20,7 +20,7 @@ export default function AuthLayout({ children }: AuthLayoutProps) {
                 <div className="relative z-20 p-12 flex flex-col justify-center items-center h-full w-full text-center">
                     <div className="mb-8 flex items-center gap-4">
                         <FaSwift className="text-white text-5xl" />
-                        <h2 className="text-5xl font-extrabold tracking-tight">Swiftly</h2>
+                        <h2 className="text-5xl font-extrabold tracking-tight">aprendeSwift</h2>
                     </div>
 
                     <p className="text-xl max-w-md font-light opacity-90">

--- a/src/app/feed.json/route.ts
+++ b/src/app/feed.json/route.ts
@@ -1,0 +1,111 @@
+// src/app/feed.json/route.ts
+
+import { NextResponse } from 'next/server';
+import { collection, getDocs, query, where, orderBy, limit } from 'firebase/firestore';
+import { db } from '@/services/firebase/config';
+import { Post } from '@/types/Post';
+import { toJSDate, createExcerpt } from '@/utils/dateUtils';
+
+const baseUrl = 'https://aprendeswift.dev';
+const siteTitle = 'aprendeSwift Blog';
+const siteDescription = 'Artículos y tutoriales sobre desarrollo web, programación y tecnología moderna';
+const authorName = 'aprendeSwift Team';
+
+export async function GET(): Promise<NextResponse> {
+    try {
+        // Get latest published posts
+        const postsQuery = query(
+            collection(db, 'posts'),
+            where('isPublished', '==', true),
+            where('status', '==', 'published'),
+            orderBy('publishedAt', 'desc'),
+            limit(20)
+        );
+
+        const postsSnapshot = await getDocs(postsQuery);
+        const posts = postsSnapshot.docs.map(doc => ({
+            id: doc.id,
+            ...doc.data()
+        } as Post));
+
+        // Generate JSON Feed items
+        const jsonItems = posts.map(post => {
+            const postUrl = post.type === 'tutorial' 
+                ? `${baseUrl}/tutorials/${post.slug}`
+                : `${baseUrl}/posts/${post.slug}`;
+            
+            const publishDate = toJSDate(post.publishedAt);
+            const excerpt = createExcerpt(post.content || post.description || '', 300);
+            
+            return {
+                id: postUrl,
+                url: postUrl,
+                title: post.title,
+                content_html: post.content || excerpt,
+                content_text: excerpt,
+                summary: post.description || excerpt,
+                date_published: publishDate.toISOString(),
+                date_modified: toJSDate(post.updatedAt).toISOString(),
+                author: {
+                    name: post.author?.name || authorName,
+                    avatar: post.author?.avatar || `${baseUrl}/icons/logo.png`,
+                },
+                tags: post.tags || [],
+                image: post.coverImage || post.imageUrl,
+                language: 'es',
+            };
+        });
+
+        // JSON Feed format
+        const jsonFeed = {
+            version: 'https://jsonfeed.org/version/1.1',
+            title: siteTitle,
+            description: siteDescription,
+            home_page_url: baseUrl,
+            feed_url: `${baseUrl}/feed.json`,
+            language: 'es',
+            icon: `${baseUrl}/icons/logo.png`,
+            favicon: `${baseUrl}/favicon.ico`,
+            authors: [
+                {
+                    name: authorName,
+                    url: baseUrl,
+                }
+            ],
+            items: jsonItems,
+        };
+
+        console.log(`Generated JSON feed with ${posts.length} posts`);
+
+        // Return JSON Feed with proper headers
+        return new NextResponse(JSON.stringify(jsonFeed, null, 2), {
+            status: 200,
+            headers: {
+                'Content-Type': 'application/feed+json; charset=utf-8',
+                'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400',
+            },
+        });
+
+    } catch (error) {
+        console.error('Error generating JSON feed:', error);
+        
+        // Return minimal JSON feed on error
+        const errorFeed = {
+            version: 'https://jsonfeed.org/version/1.1',
+            title: siteTitle,
+            description: siteDescription,
+            home_page_url: baseUrl,
+            feed_url: `${baseUrl}/feed.json`,
+            language: 'es',
+            items: [],
+        };
+
+        return new NextResponse(JSON.stringify(errorFeed, null, 2), {
+            status: 200,
+            headers: {
+                'Content-Type': 'application/feed+json; charset=utf-8',
+                'Cache-Control': 'public, max-age=300',
+            },
+        });
+    }
+}

--- a/src/app/feed.xml/route.ts
+++ b/src/app/feed.xml/route.ts
@@ -1,0 +1,117 @@
+// src/app/feed.xml/route.ts
+
+import { NextResponse } from 'next/server';
+import { collection, getDocs, query, where, orderBy, limit } from 'firebase/firestore';
+import { db } from '@/services/firebase/config';
+import { Post } from '@/types/Post';
+import { toJSDate, formatRssDate, createExcerpt, escapeXml } from '@/utils/dateUtils';
+
+const baseUrl = 'https://aprendeswift.dev';
+const siteTitle = 'aprendeSwift Blog';
+const siteDescription = 'Artículos y tutoriales sobre desarrollo web, programación y tecnología moderna';
+const siteLanguage = 'es-ES';
+const authorEmail = 'hello@aprendeswift.dev';
+
+export async function GET(): Promise<NextResponse> {
+    try {
+        // Get latest published posts
+        const postsQuery = query(
+            collection(db, 'posts'),
+            where('isPublished', '==', true),
+            where('status', '==', 'published'),
+            orderBy('publishedAt', 'desc'),
+            limit(20) // Limit to latest 20 posts
+        );
+
+        const postsSnapshot = await getDocs(postsQuery);
+        const posts = postsSnapshot.docs.map(doc => ({
+            id: doc.id,
+            ...doc.data()
+        } as Post));
+
+        // Generate RSS XML
+        const rssItems = posts.map(post => {
+            const postUrl = post.type === 'tutorial' 
+                ? `${baseUrl}/tutorials/${post.slug}`
+                : `${baseUrl}/posts/${post.slug}`;
+            
+            const publishDate = toJSDate(post.publishedAt);
+            const excerpt = createExcerpt(post.content || post.description || '', 300);
+            
+            // Generate categories from tags
+            const categories = (post.tags || [])
+                .map(tag => `        <category>${escapeXml(tag)}</category>`)
+                .join('\n');
+
+            return `    <item>
+        <title>${escapeXml(post.title)}</title>
+        <description>${escapeXml(excerpt)}</description>
+        <link>${postUrl}</link>
+        <guid isPermaLink="true">${postUrl}</guid>
+        <pubDate>${formatRssDate(publishDate)}</pubDate>
+        <author>${authorEmail} (${escapeXml(post.author?.name || 'aprendeSwift Team')})</author>
+${categories}
+        <content:encoded><![CDATA[${post.content || excerpt}]]></content:encoded>
+    </item>`;
+        }).join('\n');
+
+        const rssXml = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0" 
+     xmlns:content="http://purl.org/rss/1.0/modules/content/"
+     xmlns:atom="http://www.w3.org/2005/Atom">
+    <channel>
+        <title>${escapeXml(siteTitle)}</title>
+        <description>${escapeXml(siteDescription)}</description>
+        <link>${baseUrl}</link>
+        <language>${siteLanguage}</language>
+        <lastBuildDate>${formatRssDate(new Date())}</lastBuildDate>
+        <ttl>60</ttl>
+        <atom:link href="${baseUrl}/feed.xml" rel="self" type="application/rss+xml" />
+        
+        <image>
+            <url>${baseUrl}/icons/logo.png</url>
+            <title>${escapeXml(siteTitle)}</title>
+            <link>${baseUrl}</link>
+            <width>144</width>
+            <height>144</height>
+        </image>
+
+${rssItems}
+    </channel>
+</rss>`;
+
+        console.log(`Generated RSS feed with ${posts.length} posts`);
+
+        // Return RSS XML with proper headers
+        return new NextResponse(rssXml, {
+            status: 200,
+            headers: {
+                'Content-Type': 'application/rss+xml; charset=utf-8',
+                'Cache-Control': 'public, max-age=3600, stale-while-revalidate=86400', // Cache for 1 hour, stale-while-revalidate for 24 hours
+            },
+        });
+
+    } catch (error) {
+        console.error('Error generating RSS feed:', error);
+        
+        // Return minimal RSS feed on error
+        const errorFeed = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+    <channel>
+        <title>${escapeXml(siteTitle)}</title>
+        <description>${escapeXml(siteDescription)}</description>
+        <link>${baseUrl}</link>
+        <language>${siteLanguage}</language>
+        <lastBuildDate>${formatRssDate(new Date())}</lastBuildDate>
+    </channel>
+</rss>`;
+
+        return new NextResponse(errorFeed, {
+            status: 200,
+            headers: {
+                'Content-Type': 'application/rss+xml; charset=utf-8',
+                'Cache-Control': 'public, max-age=300', // Shorter cache on error
+            },
+        });
+    }
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,13 +7,56 @@ import AuthInitializer from "@/components/auth/AuthInitializer";
 import { Toaster } from "sonner";
 
 export const metadata: Metadata = {
-    title: "Swiftly - Tutoriales de Swift y SwiftUI",
+    title: "aprendeSwift - Tutoriales de Swift y SwiftUI",
     description: "Publicaciones, guías y tutoriales para aprender Swift y SwiftUI de manera efectiva",
+    alternates: {
+        types: {
+            'application/rss+xml': [
+                { url: '/feed.xml', title: 'aprendeSwift Blog RSS Feed' },
+            ],
+            'application/atom+xml': [
+                { url: '/atom.xml', title: 'aprendeSwift Blog Atom Feed' },
+            ],
+            'application/feed+json': [
+                { url: '/feed.json', title: 'aprendeSwift Blog JSON Feed' },
+            ],
+        },
+    },
+    other: {
+        'msvalidate.01': '', // Add Bing verification if needed
+        'google-site-verification': '', // Add Google verification if needed
+    },
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
     return (
         <html lang="es">
+            <head>
+                {/* Feed discovery links */}
+                <link
+                    rel="alternate"
+                    type="application/rss+xml"
+                    title="aprendeSwift Blog RSS Feed"
+                    href="/feed.xml"
+                />
+                <link
+                    rel="alternate"
+                    type="application/atom+xml"
+                    title="aprendeSwift Blog Atom Feed"
+                    href="/atom.xml"
+                />
+                <link
+                    rel="alternate"
+                    type="application/feed+json"
+                    title="aprendeSwift Blog JSON Feed"
+                    href="/feed.json"
+                />
+                
+                {/* Preconnect to external domains for performance */}
+                <link rel="preconnect" href="https://firebasestorage.googleapis.com" />
+                <link rel="preconnect" href="https://fonts.googleapis.com" />
+                <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
+            </head>
             <body className={inter.className}>
                 <AuthInitializer>
                     <MainLayout>{children}</MainLayout>

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,127 @@
+// src/app/sitemap.ts
+
+import { MetadataRoute } from 'next';
+import { collection, getDocs, query, where, orderBy } from 'firebase/firestore';
+import { db } from '@/services/firebase/config';
+import { Post } from '@/types/Post';
+import { Tag } from '@/types/Tag';
+import { getLatestDate } from '@/utils/dateUtils';
+
+const baseUrl = 'https://aprendeswift.dev';
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+    try {
+        const sitemapEntries: MetadataRoute.Sitemap = [];
+
+        // Static pages
+        const staticPages = [
+            {
+                url: baseUrl,
+                lastModified: new Date(),
+                changeFrequency: 'daily' as const,
+                priority: 1.0,
+            },
+            {
+                url: `${baseUrl}/posts`,
+                lastModified: new Date(),
+                changeFrequency: 'daily' as const,
+                priority: 0.9,
+            },
+            {
+                url: `${baseUrl}/tutorials`,
+                lastModified: new Date(),
+                changeFrequency: 'daily' as const,
+                priority: 0.9,
+            },
+            {
+                url: `${baseUrl}/tags`,
+                lastModified: new Date(),
+                changeFrequency: 'weekly' as const,
+                priority: 0.8,
+            },
+            {
+                url: `${baseUrl}/contact`,
+                lastModified: new Date(),
+                changeFrequency: 'monthly' as const,
+                priority: 0.6,
+            },
+        ];
+
+        sitemapEntries.push(...staticPages);
+
+        // Get published posts
+        const postsQuery = query(
+            collection(db, 'posts'),
+            where('isPublished', '==', true),
+            where('status', '==', 'published'),
+            orderBy('publishedAt', 'desc')
+        );
+
+        const postsSnapshot = await getDocs(postsQuery);
+        const posts = postsSnapshot.docs.map(doc => ({
+            id: doc.id,
+            ...doc.data()
+        } as Post));
+
+        // Add posts to sitemap
+        for (const post of posts) {
+            const postEntry = {
+                url: `${baseUrl}/posts/${post.slug}`,
+                lastModified: getLatestDate(post.updatedAt, post.publishedAt),
+                changeFrequency: 'weekly' as const,
+                priority: post.type === 'tutorial' ? 0.8 : 0.7,
+            };
+            sitemapEntries.push(postEntry);
+
+            // Also add tutorials to their specific path
+            if (post.type === 'tutorial') {
+                const tutorialEntry = {
+                    url: `${baseUrl}/tutorials/${post.slug}`,
+                    lastModified: getLatestDate(post.updatedAt, post.publishedAt),
+                    changeFrequency: 'weekly' as const,
+                    priority: 0.8,
+                };
+                sitemapEntries.push(tutorialEntry);
+            }
+        }
+
+        // Get all tags - simplified approach since Tag interface is basic
+        const tagsQuery = query(collection(db, 'tags'));
+        const tagsSnapshot = await getDocs(tagsQuery);
+        const tags = tagsSnapshot.docs.map(doc => ({
+            id: doc.id,
+            ...doc.data()
+        } as Tag & { slug?: string; updatedAt?: Date }));
+
+        // Add tags to sitemap
+        for (const tag of tags) {
+            // Generate slug from name if not present
+            const tagData = tag as Tag & { slug?: string; updatedAt?: Date };
+            const slug = tagData.slug || tag.name.toLowerCase().replace(/\s+/g, '-').replace(/[^a-z0-9-]/g, '');
+            
+            const tagEntry = {
+                url: `${baseUrl}/tags/${slug}`,
+                lastModified: getLatestDate(tagData.updatedAt, null),
+                changeFrequency: 'weekly' as const,
+                priority: 0.6,
+            };
+            sitemapEntries.push(tagEntry);
+        }
+
+        console.log(`Generated sitemap with ${sitemapEntries.length} entries`);
+        return sitemapEntries;
+
+    } catch (error) {
+        console.error('Error generating sitemap:', error);
+        
+        // Return minimal sitemap if there's an error
+        return [
+            {
+                url: baseUrl,
+                lastModified: new Date(),
+                changeFrequency: 'daily',
+                priority: 1.0,
+            },
+        ];
+    }
+}

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -31,13 +31,13 @@ const Footer = () => {
                             width={40}
                             height={40}
                         />
-                        <span className="text-xl font-bold tracking-tight text-primary">Swiftly</span>
+                        <span className="text-xl font-bold tracking-tight text-primary">aprendeSwift</span>
                     </div>
                 </div>
 
                 {/* Columnas de enlaces del footer */}
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
-                    <FooterColumn title="Sobre Swiftly">
+                    <FooterColumn title="Sobre aprendeSwift">
                         <p className="text-secondary mb-4">
                             Tu recurso principal para aprender Swift y SwiftUI. Tutoriales actualizados, ejemplos
                             prácticos y recursos para todos los niveles.
@@ -61,7 +61,7 @@ const Footer = () => {
             <div className="border-t border-neutral-200 dark:border-neutral-800 py-6 bg-surface-secondary">
                 <div className="container mx-auto px-4 flex flex-col md:flex-row justify-between items-center">
                     <p className="text-secondary text-sm">
-                        © {new Date().getFullYear()} Swiftly. Todos los derechos reservados.
+                        © {new Date().getFullYear()} aprendeSwift. Todos los derechos reservados.
                     </p>
                     <div className="flex space-x-6 mt-4 md:mt-0">
                         <FooterLink href="/privacidad">Política de privacidad</FooterLink>

--- a/src/components/layout/footer/FooterSocialLinks.tsx
+++ b/src/components/layout/footer/FooterSocialLinks.tsx
@@ -11,22 +11,22 @@ interface SocialLink {
 const socialLinks: SocialLink[] = [
     {
         name: "Twitter",
-        href: "https://twitter.com/swiftly",
+        href: "https://twitter.com/aprendeswift",
         icon: <TwitterIcon size={18} />,
     },
     {
         name: "GitHub",
-        href: "https://github.com/swiftly",
+        href: "https://github.com/aprendeswift",
         icon: <GithubIcon size={18} />,
     },
     {
         name: "LinkedIn",
-        href: "https://linkedin.com/in/swiftly",
+        href: "https://linkedin.com/in/aprendeswift",
         icon: <LinkedinIcon size={18} />,
     },
     {
         name: "Email",
-        href: "mailto:info@swiftly.dev",
+        href: "mailto:info@aprendeswift.dev",
         icon: <MailIcon size={18} />,
     },
 ];

--- a/src/components/layout/header/Logo.tsx
+++ b/src/components/layout/header/Logo.tsx
@@ -16,7 +16,7 @@ export default function Logo() {
                 width={40}
                 height={40}
             />
-            <span className="text-xl font-bold tracking-tight">Swiftly</span>
+            <span className="text-xl font-bold tracking-tight">aprendeSwift</span>
         </Link>
     );
 }

--- a/src/components/post/PostDetail.tsx
+++ b/src/components/post/PostDetail.tsx
@@ -28,7 +28,7 @@ export default function PostDetail({ post, branch }: PostDetailProps) {
     // Generate full URL for sharing
     const currentUrl = typeof window !== 'undefined' 
         ? window.location.href 
-        : `https://swiftly.dev/${branch}/${post.slug}`;
+        : `https://aprendeswift.dev/${branch}/${post.slug}`;
 
     return (
         <>

--- a/src/hooks/useSocialShare.ts
+++ b/src/hooks/useSocialShare.ts
@@ -28,7 +28,7 @@ const platforms: Record<string, SharePlatform> = {
     twitter: {
         name: "Twitter",
         shareUrl: (url, title, description) => 
-            `https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}&text=${encodeURIComponent(title)}${description ? `&via=SwiftlyBlog` : ''}`
+            `https://twitter.com/intent/tweet?url=${encodeURIComponent(url)}&text=${encodeURIComponent(title)}${description ? `&via=aprendeSwiftBlog` : ''}`
     },
     facebook: {
         name: "Facebook", 

--- a/src/utils/dateUtils.ts
+++ b/src/utils/dateUtils.ts
@@ -39,3 +39,81 @@ export function formatDate(dateInput: string | Date | Timestamp): string {
         return "Fecha inválida";
     }
 }
+
+/**
+ * Safely converts a Firebase Timestamp or Date to a JavaScript Date
+ */
+export function toJSDate(dateValue: Date | Timestamp | undefined | null): Date {
+    if (!dateValue) {
+        return new Date();
+    }
+    
+    if (dateValue instanceof Date) {
+        return dateValue;
+    }
+    
+    // Handle Firebase Timestamp
+    if (dateValue && typeof dateValue === 'object' && 'toDate' in dateValue) {
+        return (dateValue as Timestamp).toDate();
+    }
+    
+    // Fallback
+    return new Date();
+}
+
+/**
+ * Formats a date for RSS feeds (RFC 2822 format)
+ */
+export function formatRssDate(date: Date | Timestamp | undefined | null): string {
+    return toJSDate(date).toUTCString();
+}
+
+/**
+ * Formats a date for Atom feeds (ISO 8601 format)
+ */
+export function formatAtomDate(date: Date | Timestamp | undefined | null): string {
+    return toJSDate(date).toISOString();
+}
+
+/**
+ * Gets the more recent of two dates, useful for determining last modified times
+ */
+export function getLatestDate(date1: Date | Timestamp | undefined | null, date2: Date | Timestamp | undefined | null): Date {
+    const jsDate1 = toJSDate(date1);
+    const jsDate2 = toJSDate(date2);
+    
+    return jsDate1 > jsDate2 ? jsDate1 : jsDate2;
+}
+
+/**
+ * Creates an excerpt from content, removing HTML tags
+ */
+export function createExcerpt(content: string, maxLength: number = 300): string {
+    // Basic HTML tag removal
+    const textContent = content.replace(/<[^>]*>/g, '');
+    
+    if (textContent.length <= maxLength) {
+        return textContent;
+    }
+    
+    const truncated = textContent.substring(0, maxLength);
+    const lastSpace = truncated.lastIndexOf(' ');
+    
+    if (lastSpace > 0) {
+        return truncated.substring(0, lastSpace) + '...';
+    }
+    
+    return truncated + '...';
+}
+
+/**
+ * Escapes XML special characters for safe inclusion in XML documents
+ */
+export function escapeXml(text: string): string {
+    return text
+        .replace(/&/g, '&amp;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;');
+}

--- a/src/utils/metadataUtils.ts
+++ b/src/utils/metadataUtils.ts
@@ -1,7 +1,7 @@
 import { getPostBySlug } from "@/services/firebase/firestore/post";
 import type { Metadata } from "next";
 
-const siteUrl = "https://swifly.com";
+const siteUrl = "https://aprendeswift.dev";
 
 interface GenerateMetadataProps {
     params: Promise<{
@@ -37,7 +37,7 @@ export async function generateMetadata({ params }: GenerateMetadataProps): Promi
             url: url,
             type: "article",
             images: post.coverImage ? [{ url: post.coverImage }] : [],
-            siteName: "Swiftly",
+            siteName: "aprendeSwift",
         },
         twitter: {
             card: "summary_large_image",

--- a/src/utils/structuredData.ts
+++ b/src/utils/structuredData.ts
@@ -1,0 +1,218 @@
+// src/utils/structuredData.ts
+
+import { Post } from '@/types/Post';
+import { User } from '@/types/User';
+
+const baseUrl = 'https://aprendeswift.dev';
+const siteName = 'aprendeSwift Blog';
+const organizationName = 'aprendeSwift';
+
+export interface StructuredDataConfig {
+    type: 'website' | 'article' | 'tutorial' | 'blogPosting' | 'breadcrumb' | 'organization';
+    data: Record<string, unknown>;
+}
+
+// Organization structured data
+export function generateOrganizationLD(): object {
+    return {
+        '@context': 'https://schema.org',
+        '@type': 'Organization',
+        name: organizationName,
+        url: baseUrl,
+        logo: `${baseUrl}/icons/logo.png`,
+        sameAs: [
+            // Add social media URLs here when available
+        ],
+        contactPoint: {
+            '@type': 'ContactPoint',
+            contactType: 'customer service',
+            email: 'hello@aprendeswift.dev',
+        },
+    };
+}
+
+// Website structured data
+export function generateWebsiteLD(): object {
+    return {
+        '@context': 'https://schema.org',
+        '@type': 'WebSite',
+        name: siteName,
+        url: baseUrl,
+        description: 'Artículos y tutoriales sobre desarrollo web, programación y tecnología moderna',
+        inLanguage: 'es-ES',
+        publisher: {
+            '@type': 'Organization',
+            name: organizationName,
+            url: baseUrl,
+            logo: `${baseUrl}/icons/logo.png`,
+        },
+        potentialAction: {
+            '@type': 'SearchAction',
+            target: {
+                '@type': 'EntryPoint',
+                urlTemplate: `${baseUrl}/posts?search={search_term_string}`,
+            },
+            'query-input': 'required name=search_term_string',
+        },
+    };
+}
+
+// Article structured data
+export function generateArticleLD(post: Post, author?: User): object {
+    const postUrl = post.type === 'tutorial' 
+        ? `${baseUrl}/tutorials/${post.slug}`
+        : `${baseUrl}/posts/${post.slug}`;
+
+    const publishDate = post.publishedAt || new Date();
+    const modifiedDate = post.updatedAt || publishDate;
+
+    const authorData = author || post.author;
+
+    const structuredData: Record<string, unknown> = {
+        '@context': 'https://schema.org',
+        '@type': post.type === 'tutorial' ? 'TechArticle' : 'BlogPosting',
+        headline: post.title,
+        description: post.description || post.metaDescription,
+        url: postUrl,
+        datePublished: publishDate.toISOString(),
+        dateModified: modifiedDate.toISOString(),
+        inLanguage: 'es-ES',
+        author: {
+            '@type': 'Person',
+            name: authorData?.name || 'aprendeSwift Team',
+            url: authorData?.socialLinks?.linkedin || baseUrl,
+        },
+        publisher: {
+            '@type': 'Organization',
+            name: organizationName,
+            url: baseUrl,
+            logo: {
+                '@type': 'ImageObject',
+                url: `${baseUrl}/icons/logo.png`,
+                width: 144,
+                height: 144,
+            },
+        },
+        mainEntityOfPage: {
+            '@type': 'WebPage',
+            '@id': postUrl,
+        },
+    };
+
+    // Add image if available
+    if (post.coverImage || post.imageUrl) {
+        structuredData.image = {
+            '@type': 'ImageObject',
+            url: post.coverImage || post.imageUrl,
+            alt: post.title,
+        };
+    }
+
+    // Add keywords if available
+    if (post.keywords && post.keywords.length > 0) {
+        structuredData.keywords = post.keywords.join(', ');
+    }
+
+    // Add categories/tags
+    if (post.tags && post.tags.length > 0) {
+        structuredData.about = post.tags.map(tag => ({
+            '@type': 'Thing',
+            name: tag,
+        }));
+    }
+
+    // Add article section for tutorials
+    if (post.type === 'tutorial') {
+        structuredData.articleSection = 'Tutorial';
+        structuredData.educationalLevel = post.level || 'Beginner';
+        
+        // Add skill level and learning objectives if available
+        if (post.level) {
+            structuredData.educationalLevel = post.level;
+        }
+    }
+
+    // Add engagement metrics if available
+    if (post.views) {
+        structuredData.interactionStatistic = {
+            '@type': 'InteractionCounter',
+            interactionType: 'https://schema.org/ReadAction',
+            userInteractionCount: post.views,
+        };
+    }
+
+    return structuredData;
+}
+
+// Breadcrumb structured data
+export function generateBreadcrumbLD(breadcrumbs: Array<{ name: string; url: string }>): object {
+    return {
+        '@context': 'https://schema.org',
+        '@type': 'BreadcrumbList',
+        itemListElement: breadcrumbs.map((breadcrumb, index) => ({
+            '@type': 'ListItem',
+            position: index + 1,
+            name: breadcrumb.name,
+            item: breadcrumb.url,
+        })),
+    };
+}
+
+// Blog structured data for listing pages
+export function generateBlogLD(): object {
+    return {
+        '@context': 'https://schema.org',
+        '@type': 'Blog',
+        name: siteName,
+        description: 'Artículos y tutoriales sobre desarrollo web, programación y tecnología moderna',
+        url: `${baseUrl}/posts`,
+        inLanguage: 'es-ES',
+        publisher: {
+            '@type': 'Organization',
+            name: organizationName,
+            url: baseUrl,
+            logo: `${baseUrl}/icons/logo.png`,
+        },
+    };
+}
+
+// Collection page (tags) structured data
+export function generateCollectionPageLD(tagName: string, tagSlug: string, posts: Post[]): object {
+    return {
+        '@context': 'https://schema.org',
+        '@type': 'CollectionPage',
+        name: `Artículos sobre ${tagName}`,
+        description: `Todos los artículos y tutoriales etiquetados con ${tagName}`,
+        url: `${baseUrl}/tags/${tagSlug}`,
+        inLanguage: 'es-ES',
+        mainEntity: {
+            '@type': 'ItemList',
+            numberOfItems: posts.length,
+            itemListElement: posts.map((post, index) => ({
+                '@type': 'ListItem',
+                position: index + 1,
+                url: post.type === 'tutorial' 
+                    ? `${baseUrl}/tutorials/${post.slug}`
+                    : `${baseUrl}/posts/${post.slug}`,
+                name: post.title,
+            })),
+        },
+    };
+}
+
+// Helper function to inject structured data into page head
+export function generateStructuredDataScript(data: object): string {
+    return `<script type="application/ld+json">${JSON.stringify(data, null, 2)}</script>`;
+}
+
+// Helper function to combine multiple structured data objects
+export function combineStructuredData(dataObjects: object[]): object {
+    if (dataObjects.length === 1) {
+        return dataObjects[0];
+    }
+
+    return {
+        '@context': 'https://schema.org',
+        '@graph': dataObjects,
+    };
+}


### PR DESCRIPTION
Changes the project name from "Swiftly" to "aprendeSwift" across various components, improving brand consistency.

Introduces a robots.txt file for SEO optimization and creates feeds (RSS, Atom, and JSON) to enhance content distribution.

Updates metadata and footer links to reflect the new project name, ensuring a cohesive user experience.

Closes #123