### PR TITLE
feat: make post level optional for flexible content categorization

### DIFF
--- a/src/components/tutorials/TutorialCard.tsx
+++ b/src/components/tutorials/TutorialCard.tsx
@@ -11,7 +11,7 @@ type TutorialCardProps = {
 };
 
 export default function TutorialCard({ tutorial, searchTerm = "" }: TutorialCardProps) {
-    const levelStyle = LEVEL_COLORS[tutorial.level];
+    const levelStyle = tutorial.level ? LEVEL_COLORS[tutorial.level] : null;
 
     return (
         <Link
@@ -37,11 +37,13 @@ export default function TutorialCard({ tutorial, searchTerm = "" }: TutorialCard
                         {tutorial.readTime} min
                     </span>
 
-                    <span
-                        className={`px-2 py-1 rounded-full capitalize text-white/70 ${levelStyle.badge || "bg-white/10"}`}
-                    >
-                        {tutorial.level}
-                    </span>
+                    {tutorial.level && levelStyle && (
+                        <span
+                            className={`px-2 py-1 rounded-full capitalize text-white/70 ${levelStyle.badge || "bg-white/10"}`}
+                        >
+                            {tutorial.level}
+                        </span>
+                    )}
                 </div>
             </div>
         </Link>

--- a/src/constants/post.ts
+++ b/src/constants/post.ts
@@ -2,7 +2,8 @@
 
 import { PostType, PostLevel } from "@/types/Post";
 
-export const LEVEL_OPTIONS: { value: PostLevel; label: string }[] = [
+export const LEVEL_OPTIONS: { value: PostLevel | ""; label: string }[] = [
+    { value: "", label: "Sin nivel" },
     { value: "Principiante", label: "Principiante" },
     { value: "Intermedio", label: "Intermedio" },
     { value: "Avanzado", label: "Avanzado" },

--- a/src/hooks/usePostForm.ts
+++ b/src/hooks/usePostForm.ts
@@ -98,7 +98,7 @@ export default function usePostForm({ selectedPost }: PostFormOptions) {
     const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => {
         const { name, value } = e.target;
 
-        if (name.includes(".")) {
+        if (name && name.includes(".")) {
             const [parent, child] = name.split(".");
             setPost((prev) => ({
                 ...prev,
@@ -108,7 +108,9 @@ export default function usePostForm({ selectedPost }: PostFormOptions) {
                 },
             }));
         } else {
-            setPost((prev) => ({ ...prev, [name]: value }));
+            // Convertir cadena vacía a undefined para el campo level
+            const processedValue = name === 'level' && value === '' ? undefined : value;
+            setPost((prev) => ({ ...prev, [name]: processedValue }));
         }
     };
 

--- a/src/types/Post.ts
+++ b/src/types/Post.ts
@@ -22,7 +22,7 @@ export interface Post {
 
     // Categorización
     tags: string[];
-    level: PostLevel;
+    level?: PostLevel;
     type: PostType;
 
     // Multimedia


### PR DESCRIPTION
## Summary
- Make post level field optional to support content that doesn't fit traditional difficulty levels
- Add "Sin nivel" option in admin form for posts like "Zero to Hero"
- Update UI components to handle optional levels gracefully
- Fix form validation errors when level is undefined

## Changes Made
- **Post Type**: Changed `level: PostLevel` to `level?: PostLevel` in Post interface
- **Admin Form**: Added "Sin nivel" option to level dropdown in post creation/editing
- **TutorialCard Component**: Added conditional rendering for level badges when level is undefined
- **usePostForm Hook**: Fixed error handling for undefined name field and empty level values

## Test Plan
- [x] Verify linting and TypeScript checks pass
- [ ] Test creating a new post without selecting a level
- [ ] Test editing existing posts to remove level
- [ ] Verify tutorial cards display correctly with and without levels
- [ ] Check that filtering still works properly with posts that have no level

This allows content creators to publish comprehensive tutorials like "Zero to Hero" guides without forcing them into artificial difficulty categories.

🤖 Generated with [Claude Code](https://claude.ai/code)