### PR TITLE
fix: correct PR comment logic to show actual CI status

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,9 +52,7 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const status = context.job === 'success' || 
-                          (context.eventName === 'pull_request' && 
-                           context.payload.action === 'synchronize') ? 
+            const status = '${{ job.status }}' === 'success' ? 
                           '✅ CI checks passed successfully!' : 
                           '❌ CI checks failed';
             


### PR DESCRIPTION
## Summary
- Fix job status check in GitHub Actions workflow that was causing incorrect PR comments
- Replace `context.job === 'success'` with `'${{ job.status }}' === 'success'`
- Now shows ✅ when CI actually passes instead of always showing ❌

## Problem
The PR comment automation was always showing "❌ CI checks failed" even when all checks passed successfully. This was because `context.job` contains the job name ("ci"), not the job status.

## Solution
Use the proper GitHub Actions context `${{ job.status }}` to check the actual job execution status.

## Test plan
- [x] Create PR to trigger CI
- [ ] Verify CI runs successfully
- [ ] Confirm PR comment shows ✅ when CI passes
- [ ] Confirm PR comment shows ❌ when CI fails

🤖 Generated with [Claude Code](https://claude.ai/code)