### PR TITLE
fix: remove showTags prop from ContentFilters usage

### DIFF
--- a/src/app/posts/page.tsx
+++ b/src/app/posts/page.tsx
@@ -36,7 +36,6 @@ export default async function PostsPage(props: {
                     levelLabel="Nivel"
                     showViewToggle={true}
                     showSortOptions={true}
-                    showTags={true}
                     showMobileFilters={true}
                 />
             }

--- a/src/app/tutorials/page.tsx
+++ b/src/app/tutorials/page.tsx
@@ -36,7 +36,6 @@ export default async function TutorialsPage(props: {
                     levelLabel="Nivel de dificultad"
                     showViewToggle={true}
                     showSortOptions={true}
-                    showTags={true}
                     showMobileFilters={true}
                 />
             }


### PR DESCRIPTION
## Summary
Fix TypeScript build errors by removing showTags prop from ContentFilters usage.

## Problem
TypeScript build was failing with error:
```
Property 'showTags' does not exist on type 'IntrinsicAttributes & ContentFiltersProps'
```

## Solution
- Remove `showTags={true}` prop from ContentFilters in posts/page.tsx and tutorials/page.tsx
- The property was not defined in the ContentFiltersProps interface

## Test plan
- [x] Local build passes successfully
- [x] TypeScript errors resolved

🤖 Generated with [Claude Code](https://claude.ai/code)