### PR TITLE
fix: test auto-promote workflow permissions

### DIFF
--- a/.github/workflows/auto-promote.yml
+++ b/.github/workflows/auto-promote.yml
@@ -7,6 +7,8 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  actions: read
+  repository-projects: read
 
 jobs:
   auto-promote:


### PR DESCRIPTION
## Summary
Test the auto-promote workflow after configuring repository permissions.

## Changes
- Minor permission addition to workflow
- Test that workflow can now create PRs automatically

## Purpose
This PR will test if the auto-promote workflow can create PRs after:
- ✅ Enabling 'Read and write permissions' in repo settings
- ✅ Allowing 'GitHub Actions to create and approve pull requests'

## Expected behavior after merge
- Workflow should auto-create PR from develop to release
- No more permission errors

🤖 Generated with [Claude Code](https://claude.ai/code)